### PR TITLE
Fix missing `goto` and clarify some CLI documentation

### DIFF
--- a/yhunwrap/cmdline.ggo
+++ b/yhunwrap/cmdline.ggo
@@ -14,6 +14,6 @@
 # limitations under the License.
 #
 
-option "in" - "Input data (filename)" string
+option "in" - "Input data as base64 (filename)" string
 option "out" - "Output data (filename)" string
-option "wrapkey" k "Key to wrap data with (filename)" string
+option "wrapkey" k "Key to unwrap data with as binary (filename)" string

--- a/yhunwrap/main.c
+++ b/yhunwrap/main.c
@@ -289,6 +289,7 @@ int main(int argc, char *argv[]) {
   size_t wrapkey_buf_len = sizeof(wrapkey_buf);
   if (read_file(wrapkey_file, wrapkey_buf, &wrapkey_buf_len) == false) {
     fprintf(stderr, "Unable to read wrapkey file\n");
+    goto main_exit;
   }
 
   output_file = open_file(args_info.out_arg, false);


### PR DESCRIPTION
This PR polishes some rough edges on https://github.com/Yubico/yubihsm-shell/pull/323.

Specifically:
- Fix a missing `goto` statement that lets `yhunwrap` continue to execute after encountering an error condition
- `s/wrap/unwrap` in the CLI documentation, since that's what this new binary does
- Specify the expected format for the files that are input / output from this program. 
 
Feel free to disregard point 3 if it seems extraneous. However, anecdotally, I spent a fair bit of time trying to figure out why my decrypt operations were failing before realizing that the input formats for the files are different. Perhaps this is obvious if you regularly work with `yubihsm-shell`, but it wasn't to me (and in general, I find the lack of documentation on file formats in `yubihsm-shell` to be frustrating so it's possible I'm missing something). 